### PR TITLE
Revert "Bump vanilla-os/vib-gh-action from 0.8.1 to 1.0.0"

### DIFF
--- a/.github/workflows/vib-build.yml
+++ b/.github/workflows/vib-build.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: vanilla-os/vib-gh-action@v1.0.0
+      - uses: vanilla-os/vib-gh-action@v0.8.1
         with:
           recipe: "recipe.yml"
           plugins: "Vanilla-OS/vib-fsguard:v1.5.3"


### PR DESCRIPTION
Reverts Kanola-Images/Base-Image#10 (is broken)