### PR TITLE
Fix using vib 1.0.2

### DIFF
--- a/modules/00-vanilla-first-setup.yml
+++ b/modules/00-vanilla-first-setup.yml
@@ -5,4 +5,4 @@ sources:
     url: https://github.com/Vanilla-OS/first-setup/releases/download/v3.1.0/vanilla-first-setup.deb
     checksum: e8912fed9f38a8816afbde99df1e034734ac8038c80bb2ae8903cb89100e3610
 commands:
-  - apt-get install -y /sources/vanilla-first-setup/vanilla-first-setup.deb
+  - apt-get install -y /sources/vanilla-first-setup/vanilla-first-setup/vanilla-first-setup.deb

--- a/modules/00-vanilla-system-operator.yml
+++ b/modules/00-vanilla-system-operator.yml
@@ -37,8 +37,8 @@ modules:
     - type: tar
       url: https://github.com/Vanilla-OS/vso-gnome-ext/archive/refs/tags/1.3.tar.gz
   commands:
-  - mkdir -p /usr/share/gnome-shell/1.3/extensions/
-  - mv /sources/vso-gnome-ext/vso-gnome-ext-1.3/vso\@vanillaos.org /usr/share/gnome-shell/extensions/vso\@vanillaos.org
+  - mkdir -p /usr/share/gnome-shell/extensions/
+  - mv /sources/vso-gnome-ext/1.3/vso-gnome-ext-1.3/vso\@vanillaos.org /usr/share/gnome-shell/extensions/vso\@vanillaos.org
 
 - name: vso-deps-install
   type: apt

--- a/modules/02-waydroid-modules.yml
+++ b/modules/02-waydroid-modules.yml
@@ -1,8 +1,8 @@
 name: waydroid-modules
 type: shell
 commands:
-- cp -rT /sources/waydroid-modules/binder /usr/src/waydroid-binder-1
-- cp -rT /sources/waydroid-modules/ashmem /usr/src/waydroid-ashmem-1
+- cp -rT /sources/waydroid-modules/anbox-modules/binder /usr/src/waydroid-binder-1
+- cp -rT /sources/waydroid-modules/anbox-modules/ashmem /usr/src/waydroid-ashmem-1
 - dkms install waydroid-binder/1 -k $(cat /usr/share/vanilla/kernel-version)
 - dkms install waydroid-ashmem/1 -k $(cat /usr/share/vanilla/kernel-version)
 sources:

--- a/recipe.yml
+++ b/recipe.yml
@@ -5,7 +5,7 @@ vibversion: 1.0.1
 stages:
 - id: build
   base: ghcr.io/vanilla-os/core:main
-  singlelayer: false
+  addincludes: true
   labels:
     maintainer: Kanola Contributors
   args:


### PR DESCRIPTION
Tested [here](https://github.com/nisel11/Base-Image/actions/runs/14600971533)
If my PR in vib-gh-action is accepted, I will update this PR to use vanilla-os/vib-gh-action@v1.0.2 instead of nisel11/vib-gh-action@bump-v1.0.2.